### PR TITLE
Remover comentário 'type: ignore' de uma função tipada

### DIFF
--- a/graphs/fertility.py
+++ b/graphs/fertility.py
@@ -45,7 +45,7 @@ def create_chart(
     df: DataFrame,
     labels: dict[str, str] = labels,
     config: dict[str, Any] = config,
-) -> Figure: # type: ignore
+) -> Figure: 
     chart = px.line( # type: ignore
         df,
         x="year",


### PR DESCRIPTION
Este PR tem como remover um pequeno erro em um comentário do arquivo `graphs/fertility.py`.